### PR TITLE
Fix description typo EMACscript → ECMAScript

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -3,7 +3,7 @@
     "name":         "Symbol",
     "version":      "0.0.4",
     "auth":         "github:grondilu",
-    "description":  "EMACscript's Symbol for Perl 6",
+    "description":  "ECMAScript's Symbol for Perl 6",
     "licence":      "MIT",
     "depends":      [ "UUID" ],
     "provides":     {
@@ -11,4 +11,3 @@
     },
     "source-url":  "git://github.com/grondilu/symbol"
 }
-


### PR DESCRIPTION
The META6.json's [`description` line](https://github.com/grondilu/symbol/blob/2e59c95c2709df489ac009ea87f4aacbf5f60644/META6.json#L6) has a typo, which gets propagated into CPAN searches and the
https://modules.perl6.org/ snippets, so it should be fixed.